### PR TITLE
bump: version mckit-nuclides 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mckit-nuclides"
-version = "0.3.3a0"
+version = "0.3.3"
 description = "Python tools to work with elements and isotopes"
 authors = ["dvp <dmitri_portnov@yahoo.com>"]
 license = "MIT"


### PR DESCRIPTION
Previous release failed to deploy to PyPI due to request to verify again the user's e-mail. 
It's fixed now. Run release once again using the next version.